### PR TITLE
fix: update epoch for shielded convert fn

### DIFF
--- a/lib/src/sdk/mod.rs
+++ b/lib/src/sdk/mod.rs
@@ -928,11 +928,12 @@ impl Sdk {
         shielded.utils.chain_id = chain_id.clone();
         shielded.load().await?;
 
+        let epoch = rpc::query_masp_epoch(self.namada.client()).await?;
+        
         let (_, masp_value) = shielded
             .convert_namada_amount_to_masp(
                 self.namada.client(),
-                // Masp epoch should not matter
-                MaspEpoch::zero(),
+                epoch,
                 &token,
                 amount.denom(),
                 amount.amount(),


### PR DESCRIPTION
This update is to fix the `simulateShieldedRewards` function in Namadillo:

 https://github.com/anoma/namada-interface/pull/2033#discussion_r2104222634